### PR TITLE
Adds config for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 1
+updates:
+  # NPM
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    target-branch: 'main'
+    versioning-strategy: 'increase'
+    allow:
+      - dependency-type: 'all'
+    assignees:
+      - 1Solon
+    labels:
+      - 'fix'
+
+  # Docker
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    target-branch: 'main'
+    versioning-strategy: 'increase'
+    assignees:
+      - 1Solon
+    labels:
+      - 'fix'


### PR DESCRIPTION
# Dependabot

Dependabot is a GitHub app that automates dependency updates. It creates pull requests to keep dependencies secure and up-to-date.

It's a feature GitHub offers which we haven't enabled as yet. We should consider enabling it. It'll certainly make our lives easier as far as updating goes.

You can find more information [here](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)

## Change Log

- Adds config for dependabot
