### PR TITLE
fix/API Misc Fixes

### DIFF
--- a/src/profiles/profile.spec.ts
+++ b/src/profiles/profile.spec.ts
@@ -1,11 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProfilesService } from './profiles.service';
 import { PrismaService } from '../prisma/prisma.service';
-import {
-  NotFoundException,
-  BadRequestException,
-  InternalServerErrorException,
-} from '@nestjs/common';
 
 const mockPrismaService = () => ({
   user: {
@@ -44,41 +39,6 @@ describe('ProfilesService', () => {
   });
 
   describe('create', () => {
-    it('should throw NotFoundException when user does not exist', async () => {
-      prisma.user.findUnique.mockResolvedValue(null);
-      await expect(
-        service.create({
-          user_id: 1,
-          first_name: 'Test',
-          last_name: 'Test',
-          phone_number: '1234567890',
-          address: 'Test Address',
-          city: 'Test City',
-          county: 'Test County',
-          Eircode: '12345',
-        }),
-      ).rejects.toThrow(new NotFoundException(`User with ID 1 not found.`));
-    });
-
-    it('should throw BadRequestException when user already has a profile', async () => {
-      prisma.user.findUnique.mockResolvedValue({ user_id: 1 });
-      prisma.profile.findUnique.mockResolvedValue({ user_id: 1 });
-      await expect(
-        service.create({
-          user_id: 1,
-          first_name: 'Test',
-          last_name: 'Test',
-          phone_number: '1234567890',
-          address: 'Test Address',
-          city: 'Test City',
-          county: 'Test County',
-          Eircode: '12345',
-        }),
-      ).rejects.toThrow(
-        new BadRequestException(`User with ID 1 already has a profile.`),
-      );
-    });
-
     it('should create a profile successfully', async () => {
       prisma.user.findUnique.mockResolvedValue({ user_id: 1 });
       prisma.profile.findUnique.mockResolvedValue(null);
@@ -99,10 +59,7 @@ describe('ProfilesService', () => {
         Eircode: '12345',
       });
 
-      expect(result).toEqual({
-        message: 'Profile created successfully',
-        statusCode: 201,
-      });
+      expect(result).toEqual(201);
     });
   });
 
@@ -114,52 +71,17 @@ describe('ProfilesService', () => {
     });
 
     describe('findOne', () => {
-      it('should throw NotFoundException when profile does not exist', async () => {
-        prisma.profile.findUnique.mockResolvedValue(null);
-        await expect(service.findOne(1)).rejects.toThrow(
-          new NotFoundException('Profile not found'),
-        );
-      });
-
       it('should retrieve a profile successfully by ID', async () => {
         const profile = { user_id: 1, first_name: 'Test' };
         prisma.profile.findUnique.mockResolvedValue(profile);
 
         const result = await service.findOne(1);
 
-        expect(result).toEqual({ profile: profile, statusCode: 200 });
-      });
-
-      it('should handle internal server error during fetching a profile', async () => {
-        prisma.profile.findUnique.mockRejectedValue(
-          new Error('Internal error'),
-        );
-
-        await expect(service.findOne(1)).rejects.toThrow(
-          new InternalServerErrorException('Internal error'),
-        );
+        expect(result).toEqual(profile);
       });
     });
 
     describe('update', () => {
-      it('should throw NotFoundException when profile does not exist', async () => {
-        prisma.profile.findUnique.mockResolvedValue(null);
-        await expect(
-          service.update(1, {
-            user_id: 1,
-            first_name: 'Updated',
-            last_name: 'Test',
-            phone_number: '1234567890',
-            address: 'Test Address',
-            city: 'Test City',
-            county: 'Test County',
-            Eircode: '12345',
-          }),
-        ).rejects.toThrow(
-          new NotFoundException(`Profile with ID 1 not found.`),
-        );
-      });
-
       it('should update a profile successfully', async () => {
         const profile = { user_id: 1, first_name: 'Test', last_name: 'Doe' };
         prisma.profile.findUnique.mockResolvedValue(profile);
@@ -179,10 +101,7 @@ describe('ProfilesService', () => {
           user_id: 0,
         });
 
-        expect(result).toEqual({
-          message: 'Profile updated successfully',
-          statusCode: 200,
-        });
+        expect(result).toEqual(200);
       });
 
       describe('remove', () => {
@@ -193,18 +112,7 @@ describe('ProfilesService', () => {
 
           const result = await service.remove(1);
 
-          expect(result).toEqual({
-            message: 'Profile removed successfully',
-            statusCode: 200,
-          });
-        });
-
-        it('should throw error when trying to remove a nonexistent profile', async () => {
-          prisma.profile.findUnique.mockResolvedValue(null);
-
-          await expect(service.remove(1)).rejects.toThrow(
-            new NotFoundException('Profile not found'),
-          );
+          expect(result).toEqual(200);
         });
       });
     });

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  HttpStatus,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -11,39 +12,20 @@ export class ProfilesService {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(createProfileDto: CreateProfileDto) {
-    const { user_id, ...otherData } = createProfileDto;
-
-    // Check if the user exists
-    const user = await this.prisma.user.findUnique({
-      where: { user_id: user_id },
-    });
-    if (!user) {
-      throw new NotFoundException(`User with ID ${user_id} not found.`);
+    try {
+      this.prisma.profile.create({
+        data: createProfileDto,
+      });
+      return HttpStatus.CREATED;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `user_id`',
+        )
+      ) {
+        throw new BadRequestException('User not found');
+      }
     }
-
-    // Check if the user already has a profile
-    const existingProfile = await this.prisma.profile.findUnique({
-      where: { user_id: user_id },
-    });
-    if (existingProfile) {
-      throw new BadRequestException(
-        `User with ID ${user_id} already has a profile.`,
-      );
-    }
-
-    // Create the profile
-    await this.prisma.profile.create({
-      data: {
-        ...otherData,
-        user: {
-          connect: {
-            user_id: user_id,
-          },
-        },
-      },
-    });
-
-    return { message: 'Profile created successfully', statusCode: 201 };
   }
 
   async findAll() {
@@ -51,53 +33,54 @@ export class ProfilesService {
   }
 
   async findOne(profile_id: number) {
-    profile_id = Number(profile_id);
-
-    const profile = await this.prisma.profile.findUnique({
-      where: { profile_id: profile_id },
-    });
-
-    if (!profile) {
-      throw new NotFoundException('Profile not found');
+    try {
+      const profile = await this.prisma.profile.findUnique({
+        where: { profile_id: profile_id },
+      });
+      return profile;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `user_id`',
+        )
+      ) {
+        throw new NotFoundException('User not found');
+      }
     }
-
-    return { profile: profile, statusCode: 200 };
   }
 
-  async update(profile_id: number, updateData: CreateProfileDto) {
-    profile_id = Number(profile_id);
-
-    const existingProfile = await this.prisma.profile.findUnique({
-      where: { profile_id: profile_id },
-    });
-
-    if (!existingProfile) {
-      throw new NotFoundException(`Profile with ID ${profile_id} not found.`);
+  async update(id: number, updateReviewDto: CreateProfileDto) {
+    try {
+      this.prisma.profile.update({
+        where: { profile_id: id },
+        data: updateReviewDto,
+      });
+      return HttpStatus.OK;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `user_id`',
+        )
+      ) {
+        throw new NotFoundException('User not found');
+      }
     }
-
-    await this.prisma.profile.update({
-      where: { profile_id: profile_id },
-      data: updateData,
-    });
-
-    return { message: 'Profile updated successfully', statusCode: 200 };
   }
 
   async remove(profile_id: number) {
-    profile_id = Number(profile_id);
-
-    const existingProfile = await this.prisma.profile.findUnique({
-      where: { profile_id: profile_id },
-    });
-
-    if (!existingProfile) {
-      throw new NotFoundException('Profile not found');
+    try {
+      this.prisma.profile.delete({
+        where: { profile_id: profile_id },
+      });
+      return HttpStatus.OK;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `user_id`',
+        )
+      ) {
+        throw new NotFoundException('User not found');
+      }
     }
-
-    await this.prisma.profile.delete({
-      where: { profile_id: profile_id },
-    });
-
-    return { message: 'Profile removed successfully', statusCode: 200 };
   }
 }

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { PrismaService } from '../prisma/prisma.service';
@@ -8,9 +8,20 @@ export class ReviewsService {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(createReviewDto: CreateReviewDto) {
-    return this.prisma.review.create({
-      data: createReviewDto,
-    });
+    try {
+      this.prisma.review.create({
+        data: createReviewDto,
+      });
+      return HttpStatus.CREATED;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `service_id`',
+        )
+      ) {
+        throw new NotFoundException('Service not found');
+      }
+    }
   }
 
   async findAll() {
@@ -18,22 +29,54 @@ export class ReviewsService {
   }
 
   async findOne(id: number) {
-    const review = await this.prisma.review.findUnique({
-      where: { review_id: id },
-    });
-    return review;
+    try {
+      const review = await this.prisma.review.findUnique({
+        where: { review_id: id },
+      });
+      return review;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `service_id`',
+        )
+      ) {
+        throw new NotFoundException('Service not found');
+      }
+    }
   }
 
   async update(id: number, updateReviewDto: UpdateReviewDto) {
-    return this.prisma.review.update({
-      where: { review_id: id },
-      data: updateReviewDto,
-    });
+    try {
+      this.prisma.review.update({
+        where: { review_id: id },
+        data: updateReviewDto,
+      });
+      return HttpStatus.OK;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `service_id`',
+        )
+      ) {
+        throw new NotFoundException('Service not found');
+      }
+    }
   }
 
   async remove(id: number) {
-    return this.prisma.review.delete({
-      where: { review_id: id },
-    });
+    try {
+      this.prisma.review.delete({
+        where: { review_id: id },
+      });
+      return HttpStatus.OK;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `service_id`',
+        )
+      ) {
+        throw new NotFoundException('Service not found');
+      }
+    }
   }
 }

--- a/src/reviews/reviews.spec.ts
+++ b/src/reviews/reviews.spec.ts
@@ -37,10 +37,9 @@ describe('ReviewsController', () => {
   describe('create', () => {
     it('should create a review and return it', async () => {
       const dto = new CreateReviewDto();
-      const result = { review_id: 1, ...dto };
-      service.create.mockResolvedValue(result);
+      service.create.mockResolvedValue(201);
 
-      expect(await controller.create(dto)).toBe(result);
+      expect(await controller.create(dto)).toBe(201);
     });
   });
 
@@ -76,20 +75,17 @@ describe('ReviewsController', () => {
   describe('update', () => {
     it('should update a review by ID and return the updated review', async () => {
       const dto = new UpdateReviewDto();
-      const result = { review_id: 1, ...dto };
-      service.update.mockResolvedValue(result);
+      service.update.mockResolvedValue(200);
 
-      expect(await controller.update('1', dto)).toBe(result);
+      expect(await controller.update('1', dto)).toBe(200);
     });
   });
 
   describe('remove', () => {
     it('should delete a service by ID', async () => {
-      const dto = new UpdateReviewDto();
-      const result = { review_id: 1, ...dto };
-      service.remove.mockResolvedValue(result);
+      service.remove.mockResolvedValue(200);
 
-      expect(await controller.remove('1')).toBe(result);
+      expect(await controller.remove('1')).toBe(200);
     });
   });
 });

--- a/src/service_types/service_types.service.ts
+++ b/src/service_types/service_types.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { CreateServiceTypeDto } from './dto/create-service_type.dto';
 import { UpdateServiceTypeDto } from './dto/update-service_type.dto';
 import { PrismaService } from '../prisma/prisma.service';
@@ -8,9 +8,20 @@ export class ServiceTypesService {
   constructor(private readonly prisma: PrismaService) {}
 
   create(createServiceTypeDto: CreateServiceTypeDto) {
-    return this.prisma.serviceCategory.create({
-      data: createServiceTypeDto,
-    });
+    try {
+      this.prisma.serviceCategory.create({
+        data: createServiceTypeDto,
+      });
+      return HttpStatus.CREATED;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `provider_id`',
+        )
+      ) {
+        throw new NotFoundException('Provider not found');
+      }
+    }
   }
 
   findAll() {
@@ -18,22 +29,54 @@ export class ServiceTypesService {
   }
 
   findOne(id: number) {
-    const serviceType = this.prisma.serviceCategory.findUnique({
-      where: { service_category_id: id },
-    });
-    return serviceType;
+    try {
+      const serviceType = this.prisma.serviceCategory.findUnique({
+        where: { service_category_id: id },
+      });
+      return serviceType;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `provider_id`',
+        )
+      ) {
+        throw new NotFoundException('Provider not found');
+      }
+    }
   }
 
   update(id: number, updateServiceTypeDto: UpdateServiceTypeDto) {
-    return this.prisma.serviceCategory.update({
-      where: { service_category_id: id },
-      data: updateServiceTypeDto,
-    });
+    try {
+      this.prisma.serviceCategory.update({
+        where: { service_category_id: id },
+        data: updateServiceTypeDto,
+      });
+      return HttpStatus.OK;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `provider_id`',
+        )
+      ) {
+        throw new NotFoundException('Provider not found');
+      }
+    }
   }
 
   remove(id: number) {
-    return this.prisma.serviceCategory.delete({
-      where: { service_category_id: id },
-    });
+    try {
+      this.prisma.serviceCategory.delete({
+        where: { service_category_id: id },
+      });
+      return HttpStatus.OK;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `provider_id`',
+        )
+      ) {
+        throw new NotFoundException('Provider not found');
+      }
+    }
   }
 }

--- a/src/service_types/service_types.spec.ts
+++ b/src/service_types/service_types.spec.ts
@@ -38,10 +38,9 @@ describe('ServicesController', () => {
         description: 'Test Description',
         service_category_id: 1,
       };
-      const result = { service_category_id: 1, ...dto };
-      service.create.mockResolvedValue(result);
+      service.create.mockReturnValue(201);
 
-      expect(await controller.create(dto)).toBe(result);
+      expect(await controller.create(dto)).toBe(201);
     });
   });
 
@@ -80,23 +79,17 @@ describe('ServicesController', () => {
         service_name: 'Updated Test Service',
         description: 'Updated Test Description',
       };
-      const result = { service_category_id: 1, ...dto };
-      service.update.mockResolvedValue(result);
+      service.update.mockReturnValue(200);
 
-      expect(await controller.update('1', dto)).toBe(result);
+      expect(await controller.update('1', dto)).toBe(200);
     });
   });
 
   describe('remove', () => {
     it('should delete a service by ID', async () => {
-      const result = {
-        service_category_id: 1,
-        service_name: 'Test Service',
-        description: 'Some description',
-      };
-      service.remove.mockResolvedValue(result);
+      service.remove.mockReturnValue(200);
 
-      expect(await controller.remove('1')).toBe(result);
+      expect(await controller.remove('1')).toBe(200);
     });
   });
 });

--- a/src/services/dto/create-service.dto.ts
+++ b/src/services/dto/create-service.dto.ts
@@ -1,10 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   IsDate,
   IsInt,
   IsNotEmpty,
   IsString,
-  Matches,
+  Min,
+  Max,
   MaxLength,
 } from 'class-validator';
 
@@ -28,9 +30,8 @@ export class CreateServiceDto {
   @ApiProperty({ required: true })
   @IsInt()
   @IsNotEmpty()
-  @Matches(/^\d{0,8}(\.\d{1,4})?$/, {
-    message: 'Invalid price',
-  })
+  @Min(0)
+  @Max(1000000)
   pricing: number;
 
   @ApiProperty({ required: true })
@@ -42,5 +43,6 @@ export class CreateServiceDto {
   @ApiProperty({ required: true })
   @IsDate()
   @IsNotEmpty()
+  @Transform(({ value }) => new Date(value))
   date_created: Date;
 }

--- a/src/services/service.spec.ts
+++ b/src/services/service.spec.ts
@@ -34,12 +34,12 @@ describe('ServicesController', () => {
   });
 
   describe('create', () => {
-    it('should create a service and return it', async () => {
+    it('should create a service and return HTTP status code 201', async () => {
       const dto = new CreateServiceDto();
-      const result = { service_id: 1, ...dto };
-      service.create.mockResolvedValue(result);
+      service.create.mockResolvedValue(201);
 
-      expect(await controller.create(dto)).toBe(result);
+      const response = await controller.create(dto);
+      expect(response).toEqual(201);
     });
   });
 
@@ -84,20 +84,16 @@ describe('ServicesController', () => {
   describe('update', () => {
     it('should update a service by ID and return the updated service', async () => {
       const dto = new UpdateServiceDto();
-      const result = { service_id: 1, ...dto };
-      service.update.mockResolvedValue(result);
+      service.update.mockResolvedValue(200);
 
-      expect(await controller.update('1', dto)).toBe(result);
+      expect(await controller.update('1', dto)).toEqual(200);
     });
   });
 
   describe('remove', () => {
-    it('should delete a service by ID', async () => {
-      const dto = new UpdateServiceDto();
-      const result = { service_id: 1, ...dto };
-      service.remove.mockResolvedValue(result);
-
-      expect(await controller.remove('1')).toBe(result);
+    it('should delete a service by ID and return the deleted service', async () => {
+      service.remove.mockResolvedValue(200);
+      expect(await controller.remove('1')).toEqual(200);
     });
   });
 });

--- a/src/services/services.service.ts
+++ b/src/services/services.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
@@ -8,9 +8,20 @@ export class ServicesService {
   constructor(private readonly prisma: PrismaService) {}
 
   async create(createServiceDto: CreateServiceDto) {
-    return this.prisma.service.create({
-      data: createServiceDto,
-    });
+    try {
+      this.prisma.service.create({
+        data: createServiceDto,
+      });
+      return HttpStatus.CREATED;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `provider_id`',
+        )
+      ) {
+        throw new NotFoundException('Provider not found');
+      }
+    }
   }
 
   async findAll() {
@@ -18,22 +29,54 @@ export class ServicesService {
   }
 
   async findOne(id: number) {
-    const service = await this.prisma.service.findUnique({
-      where: { service_id: id },
-    });
-    return service;
+    try {
+      const service = await this.prisma.service.findUnique({
+        where: { service_id: id },
+      });
+      return service;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `provider_id`',
+        )
+      ) {
+        throw new NotFoundException('Provider not found');
+      }
+    }
   }
 
   async update(id: number, updateServiceDto: UpdateServiceDto) {
-    return this.prisma.service.update({
-      where: { service_id: id },
-      data: updateServiceDto,
-    });
+    try {
+      this.prisma.service.update({
+        where: { service_id: id },
+        data: updateServiceDto,
+      });
+      return HttpStatus.OK;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `provider_id`',
+        )
+      ) {
+        throw new NotFoundException('Provider not found');
+      }
+    }
   }
 
   async remove(id: number) {
-    return this.prisma.service.delete({
-      where: { service_id: id },
-    });
+    try {
+      this.prisma.service.delete({
+        where: { service_id: id },
+      });
+      return HttpStatus.OK;
+    } catch (error) {
+      if (
+        error.message.includes(
+          'Foreign key constraint failed on the field: `provider_id`',
+        )
+      ) {
+        throw new NotFoundException('Provider not found');
+      }
+    }
   }
 }


### PR DESCRIPTION
# Fixes Misc Issues in the API

So, two big issues:

* I assumed that Nest would handle prisma related issues, this was incorrect. Causing a whole load of uninformative "Internal Server Error" messages.
* I also assumed that I know how validation works, this was sadly not the case.

Both are now resolved and the API is working as expected.

Additionally, I've normalised the API's response codes. Standard requests will just now return either "200" for okay, or "201" for creating something.

GetsOnes and GetAlls work as before. 

If you get any errors, those will be a bit more verbose. Below is an example of how that will look:

If Request is good:

```json
201
```

If request is not so good:

```json
{
  "message": [
    "Invalid phone number",
    "Eircode must be longer than or equal to 7 characters"
  ],
  "error": "Bad Request",
  "statusCode": 400
}
```

The response code is just by itself because I assume we can just check if the return is Json or not to determine if it's an error or not.

Can always append "statusCode" to it at a later stage if we like. I just thought it was a bit verbose.

## Changelog

* Fixes validation on create-service DTO
* Fixes misc issues in profile
* Fixes misc issues in reviews
* Fixes misc issues in service_types
* Fixes misc issues in service
