### PR TITLE
feature/db seeding

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "seed": "prisma db seed"
   },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
+  },
   "dependencies": {
     "@nestjs/common": "^10.2.7",
     "@nestjs/core": "^10.2.7",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "prisma db seed"
   },
   "dependencies": {
     "@nestjs/common": "^10.2.7",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
 generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
@@ -34,10 +31,8 @@ model Provider {
   date_created      DateTime    @default(now())   
   last_login        DateTime    @default(now()) 
   user_type         UserType    @default(service_provider)
-  profile           Profile?    @relation(fields: [profile_id], references: [profile_id])
-  profile_id        Int?
+  Profile           Profile?
   Contact           Contact[]  
-  contact_id        Int?
   Service           Service?
 }
 
@@ -48,7 +43,8 @@ enum UserType {
 
 model Profile {
   profile_id          Int        @id @default(autoincrement())
-  user_id             Int        @unique
+  userId              Int?       @unique
+  providerId          Int?       @unique
   first_name          String
   last_name           String
   phone_number        String     @unique
@@ -58,8 +54,8 @@ model Profile {
   Eircode             String     @unique
   profile_picture_url String?
   bio                 String?
-  user                User       @relation(fields: [user_id], references: [user_id])
-  Provider            Provider[]
+  user                User?      @relation(fields: [userId], references: [user_id])
+  provider            Provider?  @relation(fields: [providerId], references: [provider_id])
 }
 
 model ServiceCategory {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,7 +3,6 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
-  // Dummy data for User
   const user1 = await prisma.user.create({
     data: {
       username: 'johnDoe',
@@ -14,17 +13,56 @@ async function main() {
         create: {
           first_name: 'John',
           last_name: 'Doe',
-          phone_number: '1234567890',
+          phone_number: '1234567891',
           address: '123 Main St',
           city: 'Sample City',
           county: 'Sample County',
-          Eircode: '12345',
+          Eircode: 'A96NV96',
         },
       },
     },
   });
 
-  // Dummy data for Provider
+  const user2 = await prisma.user.create({
+    data: {
+      username: 'janeDoe',
+      password: 'securePass123',
+      email: 'jane.doe@email.com',
+      user_type: 'user',
+      Profile: {
+        create: {
+          first_name: 'Jane',
+          last_name: 'Doe',
+          phone_number: '1234567892',
+          address: '123 Main St',
+          city: 'Sample City',
+          county: 'Sample County',
+          Eircode: 'A96NV95',
+        },
+      },
+    },
+  });
+
+  const user3 = await prisma.user.create({
+    data: {
+      username: 'jimDoe',
+      password: 'securePass123',
+      email: 'jim.doe@email.com',
+      user_type: 'user',
+      Profile: {
+        create: {
+          first_name: 'Jim',
+          last_name: 'Doe',
+          phone_number: '1234567893',
+          address: '123 Main St',
+          city: 'Sample City',
+          county: 'Sample County',
+          Eircode: 'A96NV94',
+        },
+      },
+    },
+  });
+
   const provider1 = await prisma.provider.create({
     data: {
       username: 'janeProvider',
@@ -39,13 +77,52 @@ async function main() {
           address: '456 Secondary St',
           city: 'Provider City',
           county: 'Provider County',
-          Eircode: '54321',
+          Eircode: 'A96NV93',
         },
       },
     },
   });
 
-  // Dummy data for ServiceCategory
+  const provider2 = await prisma.provider.create({
+    data: {
+      username: 'johnProvider',
+      password: 'providerPass789',
+      email: 'john.provider@email.com',
+      user_type: 'service_provider',
+      Profile: {
+        create: {
+          first_name: 'John',
+          last_name: 'Smith',
+          phone_number: '0987654322',
+          address: '456 Secondary St',
+          city: 'Provider City',
+          county: 'Provider County',
+          Eircode: 'A96NV92',
+        },
+      },
+    },
+  });
+
+  const provider3 = await prisma.provider.create({
+    data: {
+      username: 'janeDoeProvider',
+      password: 'providerPass123',
+      email: 'jane.doe.provider@email.com',
+      user_type: 'service_provider',
+      Profile: {
+        create: {
+          first_name: 'Jane',
+          last_name: 'Doe',
+          phone_number: '0987654323',
+          address: '456 Secondary St',
+          city: 'Provider City',
+          county: 'Provider County',
+          Eircode: 'A96NV91',
+        },
+      },
+    },
+  });
+
   const serviceCategory1 = await prisma.serviceCategory.create({
     data: {
       service_name: 'Plumbing',
@@ -53,7 +130,21 @@ async function main() {
     },
   });
 
-  // Dummy data for Service
+  const serviceCategory2 = await prisma.serviceCategory.create({
+    data: {
+      service_name: 'Electrical',
+      description: 'Installation and repair of electrical systems',
+    },
+  });
+
+  const serviceCategory3 = await prisma.serviceCategory.create({
+    data: {
+      service_name: 'Landscaping',
+      description:
+        'Garden maintenance, lawn mowing, and other landscaping services',
+    },
+  });
+
   const service1 = await prisma.service.create({
     data: {
       provider_id: provider1.provider_id,
@@ -64,7 +155,26 @@ async function main() {
     },
   });
 
-  // Dummy data for Contact
+  const service2 = await prisma.service.create({
+    data: {
+      provider_id: provider2.provider_id,
+      service_type_id: serviceCategory2.service_category_id,
+      description: 'Wiring repair',
+      pricing: 59.99,
+      availability: 'Weekdays 10am-6pm',
+    },
+  });
+
+  const service3 = await prisma.service.create({
+    data: {
+      provider_id: provider3.provider_id,
+      service_type_id: serviceCategory3.service_category_id,
+      description: 'Lawn mowing',
+      pricing: 34.99,
+      availability: 'Weekends 8am-3pm',
+    },
+  });
+
   await prisma.contact.create({
     data: {
       user_id: user1.user_id,
@@ -74,13 +184,50 @@ async function main() {
     },
   });
 
-  // Dummy data for Review
+  await prisma.contact.create({
+    data: {
+      user_id: user2.user_id,
+      provider_id: provider2.provider_id,
+      who: 'user',
+      message_content: 'Do you do electrical inspections?',
+    },
+  });
+
+  await prisma.contact.create({
+    data: {
+      user_id: user3.user_id,
+      provider_id: provider3.provider_id,
+      who: 'user',
+      message_content: 'Can you help with garden maintenance?',
+    },
+  });
+
   await prisma.review.create({
     data: {
       service_id: service1.service_id,
       reviewer_id: user1.user_id,
       rating: 4.5,
       comment: 'Great service!',
+      date_posted: new Date(),
+    },
+  });
+
+  await prisma.review.create({
+    data: {
+      service_id: service2.service_id,
+      reviewer_id: user2.user_id,
+      rating: 4.7,
+      comment: 'Prompt and professional service!',
+      date_posted: new Date(),
+    },
+  });
+
+  await prisma.review.create({
+    data: {
+      service_id: service3.service_id,
+      reviewer_id: user3.user_id,
+      rating: 4.2,
+      comment: 'Did a decent job with the lawn, but missed a few spots.',
       date_posted: new Date(),
     },
   });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,96 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // Dummy data for User
+  const user1 = await prisma.user.create({
+    data: {
+      username: 'johnDoe',
+      password: 'securePass123',
+      email: 'john.doe@email.com',
+      user_type: 'user',
+      Profile: {
+        create: {
+          first_name: 'John',
+          last_name: 'Doe',
+          phone_number: '1234567890',
+          address: '123 Main St',
+          city: 'Sample City',
+          county: 'Sample County',
+          Eircode: '12345',
+        },
+      },
+    },
+  });
+
+  // Dummy data for Provider
+  const provider1 = await prisma.provider.create({
+    data: {
+      username: 'janeProvider',
+      password: 'providerPass456',
+      email: 'jane.provider@email.com',
+      user_type: 'service_provider',
+      Profile: {
+        create: {
+          first_name: 'Jane',
+          last_name: 'Smith',
+          phone_number: '0987654321',
+          address: '456 Secondary St',
+          city: 'Provider City',
+          county: 'Provider County',
+          Eircode: '54321',
+        },
+      },
+    },
+  });
+
+  // Dummy data for ServiceCategory
+  const serviceCategory1 = await prisma.serviceCategory.create({
+    data: {
+      service_name: 'Plumbing',
+      description: 'Fixing pipes and other plumbing services',
+    },
+  });
+
+  // Dummy data for Service
+  const service1 = await prisma.service.create({
+    data: {
+      provider_id: provider1.provider_id,
+      service_type_id: serviceCategory1.service_category_id,
+      description: 'Pipe fixing',
+      pricing: 49.99,
+      availability: 'Weekdays 9am-5pm',
+    },
+  });
+
+  // Dummy data for Contact
+  await prisma.contact.create({
+    data: {
+      user_id: user1.user_id,
+      provider_id: provider1.provider_id,
+      who: 'user',
+      message_content: 'Can you fix my sink?',
+    },
+  });
+
+  // Dummy data for Review
+  await prisma.review.create({
+    data: {
+      service_id: service1.service_id,
+      reviewer_id: user1.user_id,
+      rating: 4.5,
+      comment: 'Great service!',
+      date_posted: new Date(),
+    },
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
# Adds demo data command to the database

This PR adds a command to the database to seed the database with demo data. You can execute this command with the following:

    ```bash
    npm run seed
    ```

This will seed the database with three entries in each table. 

## Changes

- Adds seed command
- Updates profiles for users and providers
- In-progress seed.ts
- Adds config for seed
- Adds finished seeding script
