### PR TITLE
Fixes dockerfile

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Install dependencies
         run: npm install
@@ -30,13 +30,29 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Install dependencies
         run: npm install
 
       - name: Run linting
         run: npm run lint
+
+  Build-Test:
+    runs-on: ubuntu-latest
+
+    needs: [Mocking-Tests, Linting]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+    
+      - name: Build Docker Image (Test Build)
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: false
+    

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 FROM node:lts-alpine
 
 # Set the working directory
-WORKDIR /src
+WORKDIR /
 
 # Copy package.json and package-lock.json first for optimal caching
 COPY package*.json ./
+
+# Copy the rest of the application code
+COPY . .
 
 # Install dependencies, Nest.js CLI, and generate Prisma client
 # Combining these steps into a single RUN command reduces the number of layers
 RUN npm install && \
     npm install -g @nestjs/cli && \
     npx prisma generate
-
-# Copy the rest of the application code
-COPY . .
 
 # Build the Nest.js app
 RUN npm run build


### PR DESCRIPTION
# Hotfix for our broken on-build action

The dockerfile had some bad order-of-operations, I was doing this:

```dockerfile
    RUN npm install && \
        npm install -g @nestjs/cli && \
        npx prisma generate
```

Before this:

```dockerfile
    COPY . .
```

As you can probably imagine, building the code without the code itself is a problem.

I frankly have *zero* idea how the image was building successfully until now.

## Build Test

I've also added a build test so this doesn't happen again. It won't push to the repo, just try to build the project and fail the test if that process fails. 

## Changelog

- Fixed dockerfile
- Added build test
- Updated tests
