### PR TITLE
fix/register fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/express": "^4.17.20",
     "@types/jest": "^29.5.6",
     "@types/node": "^20.8.9",
-    "@types/passport-jwt": "^3.0.11",
+    "@types/passport-jwt": "^3.0.12",
     "@types/supertest": "^2.0.15",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,24 +14,23 @@ enum UserType {
 }
 
 model User {
-  user_id           Int       @id @default(autoincrement())
-  username          String    @unique
-  password          String
-  email             String    @unique
-  date_created      DateTime  @default(now()) @map(name: "created_at")
-  last_login        DateTime  @default(now())
-  user_type         UserType  @default(user)
-  profileId         Int       @unique
-  Review            Review?
-  Profile           Profile?   @relation(fields: [profileId], references: [profile_id])
-  servicesProvided  Service[] @relation("ProviderRelation")
-  sentContacts      Contact[] @relation("ContactUserRelation")
-  receivedContacts  Contact[] @relation("ContactProviderRelation")
+  user_id          Int       @id @default(autoincrement())
+  username         String    @unique
+  password         String
+  email            String    @unique
+  date_created     DateTime  @default(now()) @map(name: "created_at")
+  last_login       DateTime  @default(now())
+  user_type        UserType  @default(user)
+  profileId        Int       @unique
+  Review           Review?
+  Profile          Profile   @relation(fields: [profileId], references: [profile_id])
+  servicesProvided Service[] @relation("ProviderRelation")
+  sentContacts     Contact[] @relation("ContactUserRelation")
+  receivedContacts Contact[] @relation("ContactProviderRelation")
 }
 
 model Profile {
   profile_id          Int     @id @default(autoincrement())
-  user_id              Int     @unique
   first_name          String
   last_name           String
   phone_number        String  @unique

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,7 +12,6 @@ async function main() {
       user_type: UserType.user,
       Profile: {
         create: {
-          user_id: 1,
           first_name: 'John',
           last_name: 'Doe',
           phone_number: '1234567891',
@@ -33,7 +32,6 @@ async function main() {
       user_type: 'user',
       Profile: {
         create: {
-          user_id: 2,
           first_name: 'Jane',
           last_name: 'Doe',
           phone_number: '1234567892',
@@ -54,7 +52,6 @@ async function main() {
       user_type: 'user',
       Profile: {
         create: {
-          user_id: 3,
           first_name: 'Jim',
           last_name: 'Doe',
           phone_number: '1234567893',
@@ -75,7 +72,6 @@ async function main() {
       user_type: 'service_provider',
       Profile: {
         create: {
-          user_id: 4,
           first_name: 'Jane',
           last_name: 'Smith',
           phone_number: '0987654321',
@@ -96,7 +92,6 @@ async function main() {
       user_type: 'service_provider',
       Profile: {
         create: {
-          user_id: 5,
           first_name: 'John',
           last_name: 'Smith',
           phone_number: '0987654322',
@@ -117,7 +112,6 @@ async function main() {
       user_type: 'service_provider',
       Profile: {
         create: {
-          user_id: 6,
           first_name: 'Jane',
           last_name: 'Doe',
           phone_number: '0987654323',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -13,6 +14,12 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    }),
+  );
 
   await app.listen(3001);
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -28,5 +28,5 @@ export class CreateUserDto {
   @ApiProperty({ required: true })
   @IsEnum(UserType, { message: 'Invalid User Type' })
   @IsNotEmpty({ message: 'First Name Required' })
-  userType: UserType;
+  user_type: UserType;
 }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -6,6 +6,10 @@ import {
   IsEmail,
   IsStrongPassword,
   IsEnum,
+  MaxLength,
+  IsOptional,
+  Length,
+  Matches,
 } from 'class-validator';
 export class CreateUserDto {
   @ApiProperty({ required: true })
@@ -29,4 +33,59 @@ export class CreateUserDto {
   @IsEnum(UserType, { message: 'Invalid User Type' })
   @IsNotEmpty({ message: 'First Name Required' })
   user_type: UserType;
+
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(255)
+  first_name: string;
+
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(255)
+  last_name: string;
+
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @Matches(/^(\+\d{1,3}[- ]?)?\d{10}$/, {
+    message: 'Invalid phone number',
+  })
+  phone_number: string;
+
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(255)
+  address: string;
+
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(100)
+  city: string;
+
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(100)
+  county: string;
+
+  @ApiProperty({ required: true })
+  @IsNotEmpty()
+  @IsString()
+  @Length(7, 8)
+  Eircode: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  profile_picture_url?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  bio?: string;
 }

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,4 +1,32 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateUserDto } from './create-user.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { UserType } from '@prisma/client';
+import {
+  IsString,
+  IsNotEmpty,
+  IsEmail,
+  IsStrongPassword,
+  IsEnum,
+} from 'class-validator';
+export class UpdateUserDto {
+  @ApiProperty({ required: true })
+  @IsString()
+  @IsNotEmpty({ message: 'Username Required' })
+  username: string;
 
-export class UpdateUserDto extends PartialType(CreateUserDto) {}
+  @ApiProperty({ required: true })
+  @IsString()
+  @IsNotEmpty({ message: 'Email Required' })
+  @IsEmail({}, { message: 'Please enter a valid email address' })
+  email: string;
+
+  @ApiProperty({ required: true })
+  @IsStrongPassword({}, { message: 'Password not strong enough' })
+  @IsString()
+  @IsNotEmpty({ message: 'Password Required' })
+  password: string;
+
+  @ApiProperty({ required: true })
+  @IsEnum(UserType, { message: 'Invalid User Type' })
+  @IsNotEmpty({ message: 'First Name Required' })
+  user_type: UserType;
+}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -20,7 +20,6 @@ export class UsersService {
 
   async create(data: CreateUserDto) {
     try {
-      console.log(data);
       // Hash the user's password using the encodePassword function.
       data.password = encodePassword(data?.password);
       // Create a new user with the provided data.

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -20,12 +20,27 @@ export class UsersService {
 
   async create(data: CreateUserDto) {
     try {
-      // Hash the user's password using the encodePassword function.
-      data.password = encodePassword(data?.password);
-      // Create a new user with the provided data.
+      const hashedPassword = encodePassword(data?.password);
       await this.prisma.user.create({
-        data: data,
+        data: {
+          username: data.username,
+          password: hashedPassword,
+          email: data.email,
+          user_type: data.user_type,
+          Profile: {
+            create: {
+              first_name: data.first_name,
+              last_name: data.last_name,
+              phone_number: data.phone_number,
+              address: data.address,
+              city: data.city,
+              county: data.county,
+              Eircode: data.Eircode,
+            },
+          },
+        },
       });
+
       return HttpStatus.CREATED;
     } catch (error) {
       return new HttpErrorByCode['500'](error);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -20,6 +20,7 @@ export class UsersService {
 
   async create(data: CreateUserDto) {
     try {
+      console.log(data);
       // Hash the user's password using the encodePassword function.
       data.password = encodePassword(data?.password);
       // Create a new user with the provided data.

--- a/src/users/users.spec.ts
+++ b/src/users/users.spec.ts
@@ -5,6 +5,7 @@ import { JwtService } from '@nestjs/jwt';
 import { CreateUserDto } from './dto/create-user.dto';
 import { LoginUserDto } from './dto/login-user.dto';
 import * as bcrypt from '../utils/bcrypt'; // Import the whole module
+import { UpdateUserDto } from './dto/update-user.dto';
 
 // Mock at the top-level, outside of any describe or function.
 jest.mock('../utils/bcrypt');
@@ -49,7 +50,14 @@ describe('UsersService', () => {
       email: 'test@example.com',
       username: 'testuser',
       password: 'testpass',
-      userType: 'user',
+      user_type: 'user',
+      first_name: 'test',
+      last_name: 'user',
+      phone_number: '1234567890',
+      address: 'test address',
+      city: 'test city',
+      county: 'test county',
+      Eircode: 'test eircode',
     };
 
     prismaMock.user.findFirst.mockResolvedValue(null);
@@ -100,8 +108,11 @@ describe('UsersService', () => {
   });
 
   it('should return a status 200 when a user is updated', async () => {
-    const updateUserDto = {
-      email: ' ',
+    const updateUserDto: UpdateUserDto = {
+      username: 'testuser',
+      user_type: 'user',
+      email: 'test@email.com',
+      password: 'testpass',
     };
 
     prismaMock.user.update.mockResolvedValue(updateUserDto);


### PR DESCRIPTION
# Fixes the /register command

This fixes the register command, to accomodate this. I've made two changes to the schema:

```prisma
model User {
  user_id          Int       @id @default(autoincrement())
  username         String    @unique
  password         String
  email            String    @unique
  date_created     DateTime  @default(now()) @map(name: "created_at")
  last_login       DateTime  @default(now())
  user_type        UserType  @default(user)
  profileId        Int       @unique
  Review           Review?
  Profile          Profile   @relation(fields: [profileId], references: [profile_id]) // Profiles are now mandatory relations
  servicesProvided Service[] @relation("ProviderRelation")
  sentContacts     Contact[] @relation("ContactUserRelation")
  receivedContacts Contact[] @relation("ContactProviderRelation")
}
```

and

```prisma
model Profile {
  profile_id          Int     @id @default(autoincrement())
  // User ID is now removed
  first_name          String
  last_name           String
  phone_number        String  @unique
  address             String
  city                String
  county              String
  Eircode             String  @unique
  profile_picture_url String?
  bio                 String?
  user                User?
}
```

The above changes facilitate nested creation of profiles and users. The updated logic looks a bit like this:

```ts
await this.prisma.user.create({
        data: {
          username: data.username,
          password: hashedPassword,
          email: data.email,
          user_type: data.user_type,
          Profile: {
            create: {
              first_name: data.first_name,
              last_name: data.last_name,
              phone_number: data.phone_number,
              address: data.address,
              city: data.city,
              county: data.county,
              Eircode: data.Eircode,
            },
          },
        },
      });
```

## Test data

If you want to test the changes I've made, feel free to spin up the API and supply this JSON to `/users/register`

```json
{
  "username": "john_doe",
  "email": "john.doe@example.com",
  "password": "secureP@ssword123",
  "user_type": "user",
  "first_name": "John",
  "last_name": "Doe",
  "phone_number": "1234567890",
  "address": "123 Main St",
  "city": "SampleCity",
  "county": "SampleCounty",
  "Eircode": "A1B2C34",
  "profile_picture_url": "https://example.com/profiles/john_doe.jpg",
  "bio": "Hello! I'm John. I love hiking, photography, and reading books."
}
```

## Changelog

- Makes profile mandatory and removes profile_id
- Removes profile_id from seeding
- Fixes create.profile
- Adjusts create-user to support profile gen
- Adjusts update to support only user
- Fixes tests
