### PR TITLE
feature/change user guard logic

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,10 @@ async function bootstrap() {
   );
 
   app.enableCors();
-  await app.listen(3001);
+  try {
+    await app.listen(3001);
+  } catch (error) {
+    console.log("Make sure you have Database running, and at 'localhost:3006'");
+  }
 }
 bootstrap();

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -109,8 +109,7 @@ export class UsersController {
   }
 
   @Get(':id')
-  @UseGuards(JwtAuthGuard, UserOwnershipGuard)
-  @ApiBearerAuth()
+  @UseGuards() // Guards were removed here to support /search in frontend -1Solon
   @ApiOperation({ summary: 'Get a single user' })
   @ApiResponse({ status: 200, description: 'User returned successfully' })
   @ApiResponse({ status: 400, description: 'Bad Request' })


### PR DESCRIPTION
# Changes User guard logic and adds Database error message

`/search` in the frontend requires access to `/user:id`, we need to remove the guard to make this accessable.

Additionally, we need to add error logic for if the database is not up.

## Changelog

- Modifies guards on user /:id
- Adds error logic for if database is not up
