### PR TITLE
Makes reviews cascade delete on service deletion

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,7 @@ model Service {
   availability      String          @map("availability")
   date_created      DateTime        @default(now()) @map("date_created")
   provider          User            @relation("ProviderRelation", fields: [provider_id], references: [user_id])
-  Review            Review[]
+  Review            Review[]        
 }
 
 model Contact {
@@ -82,6 +82,6 @@ model Review {
   rating      Float
   comment     String?
   date_posted DateTime
-  service     Service  @relation(fields: [service_id], references: [service_id])
+  service     Service  @relation(fields: [service_id], references: [service_id], onDelete: Cascade)
   reviewer    User     @relation(fields: [reviewer_id], references: [user_id])
 }


### PR DESCRIPTION
# Makes Reviews Cascade Delete on Service Deletion

Fixes an issue where deleting a service would not complete, due to a foreign relation error. This is because the service had reviews, and the reviews were not deleted when the service was deleted.

## IMPORTANT

**This change alters the Database Schema, you will need to run `npx prisma db push` to apply the changes.**

### Changelog

- [x] Added onDelete: CASCADE to the Service model's reviews field.